### PR TITLE
TECH Add development var to ignore auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ For more explanations: https://peter.bourgon.org/go-best-practices-2016/#depende
 
 ## Configuration
 
-For development purpose, set the following environment variable to bypass the authentication and authorization process:
+Set the following environment variable to bypass the authentication and authorization process.
+⚠ This variable should be set to true only for development purpose ⚠
 
 ```export IGNORE_AUTH=true```
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ The policy for this lib regarding vendoring is not to include any dependency, un
 The main reason for this is to avoid any conflict between your project and go-chpr-middlewares.
 For more explanations: https://peter.bourgon.org/go-best-practices-2016/#dependency-management
 
+## Configuration
+
+For development purpose, set the following environment variable to bypass the authentication process:
+
+```export IGNORE_AUTH=true```
+
 ## Contribute and local installation
 
 Dependencies for developing on this project will be automatically installed when running tests:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For more explanations: https://peter.bourgon.org/go-best-practices-2016/#depende
 
 ## Configuration
 
-For development purpose, set the following environment variable to bypass the authentication process:
+For development purpose, set the following environment variable to bypass the authentication and authorization process:
 
 ```export IGNORE_AUTH=true```
 

--- a/jwtAuth.go
+++ b/jwtAuth.go
@@ -94,11 +94,6 @@ JwtAuthenticationMiddleware returns a middleware that:
 Panics if fails to parse the public key
 */
 func JwtAuthenticationMiddleware(publicKeyString string, logger *logrus.Logger) Middleware {
-	/*
-		If the IGNORE_AUTH environment variable is set to "true"
-		the middleware will bypass the authentication and authorization process
-		/!\ This variable should be set to true only for development purpose /!\
-	*/
 	if IsAuthIgnored() {
 		logger.Warn("[JwtAuthenticationMiddleware] Authentication is ignored (IGNORE_AUTH sets to true)")
 		return NoopMiddleware

--- a/jwtAuth_test.go
+++ b/jwtAuth_test.go
@@ -54,15 +54,19 @@ func TestMiddleWare_StoreInformationInRequestcontext(t *testing.T) {
 	assert.Equal(t, "Alfred Bernard", storedClaims.DisplayName)
 }
 
-func TestMiddleware_IgnoredAuthForDevelopmentMode(t *testing.T) {
+func TestMiddleware_IgnoredAuthenticationForDevelopmentMode(t *testing.T) {
 	os.Setenv("IGNORE_AUTH", "true")
 	defer os.Setenv("IGNORE_AUTH", "")
+
+	// no public key is required in this case
 	jwtMiddleware := JwtAuthenticationMiddleware("", &logrus.Logger{})
 	wrappedHandler := jwtMiddleware(fixtures.Fake200Handler)
 	recorder := httptest.NewRecorder()
 	wrappedHandler(recorder, &http.Request{})
+
 	res := recorder.Result()
 	assert.Equal(t, 200, res.StatusCode)
+
 	body, _ := ioutil.ReadAll(res.Body)
 	assert.Equal(t, "", string(body))
 }

--- a/noop_middleware.go
+++ b/noop_middleware.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/http"
+	"os"
+)
+
+/*
+IsAuthIgnored is true when the IGNORE_AUTH is properly set
+*/
+func IsAuthIgnored() bool {
+	return os.Getenv("IGNORE_AUTH") == "true"
+}
+
+/*
+NoopMiddleware is a middleware which simply pass along the handler function next()
+*/
+func NoopMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return next
+}

--- a/noop_middleware_test.go
+++ b/noop_middleware_test.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/transcovo/go-chpr-middlewares/fixtures"
+)
+
+func TestIsAuthIgnored_EnvVarSet(t *testing.T) {
+	os.Setenv("IGNORE_AUTH", "true")
+	defer os.Setenv("IGNORE_AUTH", "")
+
+	assert.Equal(t, true, IsAuthIgnored())
+}
+
+func TestIsAuthIgnored_EnvVarNotSet(t *testing.T) {
+	os.Setenv("IGNORE_AUTH", "")
+
+	assert.Equal(t, false, IsAuthIgnored())
+}
+
+func TestNoopMiddleware(t *testing.T) {
+	wrappedHandler := NoopMiddleware(fixtures.Fake200Handler)
+	// check if NoopMiddleware returns the same function
+	assert.Equal(t,
+		reflect.ValueOf(fixtures.Fake200Handler).Pointer(),
+		reflect.ValueOf(wrappedHandler).Pointer(),
+	)
+
+	recorder := httptest.NewRecorder()
+	req := &http.Request{}
+	wrappedHandler(recorder, req)
+	res := recorder.Result()
+
+	assert.Equal(t, 200, res.StatusCode)
+}

--- a/roles.go
+++ b/roles.go
@@ -13,6 +13,15 @@ role matching a pattern from a list of patterns.
 To be plugged after JwtAuthenticationMiddleware.
 */
 func RoleAuthorizationMiddleware(patterns ...string) Middleware {
+	/*
+		If the IGNORE_AUTH environment variable is set to "true"
+		the middleware will bypass the authentication and authorization process
+		/!\ This variable should be set to true only for development purpose /!\
+	*/
+	if IsAuthIgnored() {
+		return NoopMiddleware
+	}
+
 	return func(next http.HandlerFunc) http.HandlerFunc {
 		return func(res http.ResponseWriter, req *http.Request) {
 			roles := extractRoles(req)

--- a/roles.go
+++ b/roles.go
@@ -13,11 +13,6 @@ role matching a pattern from a list of patterns.
 To be plugged after JwtAuthenticationMiddleware.
 */
 func RoleAuthorizationMiddleware(patterns ...string) Middleware {
-	/*
-		If the IGNORE_AUTH environment variable is set to "true"
-		the middleware will bypass the authentication and authorization process
-		/!\ This variable should be set to true only for development purpose /!\
-	*/
 	if IsAuthIgnored() {
 		return NoopMiddleware
 	}


### PR DESCRIPTION
Add an environment variable `IGNORE_AUTH` to explicitly bypass the authentication and the role authorization process for development purpose only