### PR TITLE
TECH Make feature use more realistic iss and sub fields

### DIFF
--- a/fixtures/fixtures.json
+++ b/fixtures/fixtures.json
@@ -4,63 +4,63 @@
       "display_name": "Carl De la Batte",
       "exp": 1485969700,
       "iat": 1453225473,
-      "iss": "ab90bc58ef76",
+      "iss": "ab90bc58ef76123412341234",
       "roles": [
         {
           "name": "cp:client:rider:"
         }
       ],
-      "sub": "ab90bc58ef76"
+      "sub": "ab90bc58ef76123412341234"
     },
     "TokenValidWithEmployeeRole": {
       "display_name": "Hubert Bonisseur de La Bath",
       "iat": 1453225473,
-      "iss": "58ef76ab90bc",
+      "iss": "58ef76ab90bc123412341234",
       "roles": [
         {
           "name": "cp:employee:"
         }
       ],
-      "sub": "58ef76ab90bc"
+      "sub": "58ef76ab90bc123412341234"
     },
     "TokenValidWithRiderRole": {
       "display_name": "Alfred Bernard",
       "iat": 1453225473,
-      "iss": "58ef76ab90bc",
+      "iss": "58ef76ab90bc123412341234",
       "roles": [
         {
           "name": "cp:client:rider:"
         }
       ],
-      "sub": "58ef76ab90bc"
+      "sub": "58ef76ab90bc123412341234"
     },
     "TokenWithInvalidAlgorithm": {
       "display_name": "Alfred Bernard",
       "iat": 1453225473,
-      "iss": "58ef76ab90bc",
+      "iss": "58ef76ab90bc123412341234",
       "roles": [
         {
           "name": "cp:client:rider:"
         }
       ],
-      "sub": "58ef76ab90bc"
+      "sub": "58ef76ab90bc123412341234"
     },
     "TokenWithInvalidSignature": {
       "display_name": "Alfred Bernard",
       "iat": 1453225473,
-      "iss": "58ef76ab90bc",
+      "iss": "58ef76ab90bc123412341234",
       "roles": [
         {
           "name": "cp:client:rider:"
         }
       ],
-      "sub": "58ef76ab90bc"
+      "sub": "58ef76ab90bc123412341234"
     }
   },
-  "RawRsaPublicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0zvKD4N3DUFFDzpmO59Z\nH4gvvYGlVyGYwFoLcQ6nUVSgnoSxp84TKQbitZ7iCaEQa4v5XTA9N2bR/qNEmOMT\n3TKER+1TlNqk3ZO+WMgHhfm8RH1Ycyb6ImO1L+REKwtkoJPwOR4Bx3LV9n9omUWU\nYkEZCd231Zwf0tsgUyG+J9EUkWbLlj6+orRWttOx0xHooOlao/OnpvOn7tCwB2yW\nt/rkefi//u5bRWnsf+2LcAUpRUKYzEq6z1mI5HsgC808+9bUCp4DT2GxYh3OBj9h\nISEOioGD7aBuUUEeMqwb/axC3jOKzmeSpb/rvA2gAts11k4abq+uWim8CZ/adIb5\nbwIDAQAB\n-----END PUBLIC KEY-----\n",
-  "TokenExpired": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOiJDYXJsIERlIGxhIEJhdHRlIiwiZXhwIjoxNDg1OTY5NzAwLCJpYXQiOjE0NTMyMjU0NzMsImlzcyI6ImFiOTBiYzU4ZWY3NiIsInJvbGVzIjpbeyJuYW1lIjoiY3A6Y2xpZW50OnJpZGVyOiJ9XSwic3ViIjoiYWI5MGJjNThlZjc2In0.ohE0dmPcLPBVRkWmY_ztLRARkxxRR64lD_iQ82MwEyzYWnqbloegOj937_N1HjG-96HifVY3TIJk2moBPw5b_KNA-2Jidgv62pKTkAL6lSuJ3GYRkF_l4Ih94GN-VXgEk6DN5vQ_JznuIgrFMMKCIwaBT6qrIUUTVSL2ve3ygjaxrMJT-DbMQ209VzsDu6qRiHjaCK8mRMpTK4OguzvtlBxD5uDnTqum7fEQSFcU9kvQSEb7kvYon3qJuWlwckOgyp0zvTLABk81_uc7m4RsAj4LUDpk2DqcM-ohjzxQB3kF29owFiOE8fj8mv5H_U1eiUVY-rSJS7iwrwRdL5_ttA",
-  "TokenValidWithEmployeeRole": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOiJIdWJlcnQgQm9uaXNzZXVyIGRlIExhIEJhdGgiLCJpYXQiOjE0NTMyMjU0NzMsImlzcyI6IjU4ZWY3NmFiOTBiYyIsInJvbGVzIjpbeyJuYW1lIjoiY3A6ZW1wbG95ZWU6In1dLCJzdWIiOiI1OGVmNzZhYjkwYmMifQ.E-Rt6weAeWQ6mABZLb66GvLZxEIAeOGzmh6onC5uB9P_Cit3_FlEHKBo5OnJX2Dst7bxd5yHajpZtkrW0UL3B1_MsHukO8Cog-ii1y6fVse43vMk4GgwazrOBNfDmMXJT-R25WqqcRnh8tunkXhD6FgE9m8vOk09zwh8lMZVyE2DGhXp_JTSTQV38YHQ8oegcvRz9cQSSuBGH813zbRr4xGWAvYul8njdt4W8VieQPP4JET7v6xqD26IyA4QYn2g5w6BfHmgvCxBkwOfCoWL4HIiQhF17mDMAabSabxQTcAvIkp8ybgR_1cEJPGLo9inUSvc7q9S1O-7McJ9ww1OfQ",
-  "TokenValidWithRiderRole": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOiJBbGZyZWQgQmVybmFyZCIsImlhdCI6MTQ1MzIyNTQ3MywiaXNzIjoiNThlZjc2YWI5MGJjIiwicm9sZXMiOlt7Im5hbWUiOiJjcDpjbGllbnQ6cmlkZXI6In1dLCJzdWIiOiI1OGVmNzZhYjkwYmMifQ.MCPyDPbeaiobF7ExmEA94i8WkFO-PUhcAMBDxyss7WvezuZcooMzDSv02UCmBPAB0ynHIhPd4sdNAFzWSqc-NsrQsryaHLc_he59HFf3PgCx8dMnTEiY0NxSijEmphSp6dGUkk_BPsbzjpdBOCPo0QTxj8lzy1LjOBnNVyHrMZrvmWO-57u9onRJlNqVafONJaMB7WymGK4BZZpa5NFkd1Vi2ywCI0uv5D72rv9gJEHIwK0QxtEGhN6x7WFIhnW-_8VnMCPGpCr0kgb4x8lt_iO5g34XOiVEWnpUkNls6KawxsemUaSvB1YkN3pOQ2SQijXG4tv4J2rmIfp0ug9kjA",
-  "TokenWithInvalidAlgorithm": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOiJBbGZyZWQgQmVybmFyZCIsImlhdCI6MTQ1MzIyNTQ3MywiaXNzIjoiNThlZjc2YWI5MGJjIiwicm9sZXMiOlt7Im5hbWUiOiJjcDpjbGllbnQ6cmlkZXI6In1dLCJzdWIiOiI1OGVmNzZhYjkwYmMifQ.TBYDdzv1YJw9VKGfKSbu4tpFJ2BPfneCq4Pc1xK_rlY",
-  "TokenWithInvalidSignature": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOiJBbGZyZWQgQmVybmFyZCIsImlhdCI6MTQ1MzIyNTQ3MywiaXNzIjoiNThlZjc2YWI5MGJjIiwicm9sZXMiOlt7Im5hbWUiOiJjcDpjbGllbnQ6cmlkZXI6In1dLCJzdWIiOiI1OGVmNzZhYjkwYmMifQ.URotMOxRSo4w8NT-r3pfE58pGVO63yzbc7J9sB3HHMd9sy1rWkdFxXv_-2K3_JezRhxaRhLO1DkvawPlLXiNsyWEB853a4Tt3W4jlyGzyYvpl7iyXC_8SWmLvm_1BTwIGJrPOCQPx-aDYaYKef4ARb5Rz5FdG8pAKYg9UtMKQ51uhk98K6axUtM6MDZC1BtwcM-mvfZNSpP9OrG0eY1WSe6CRRaaKYHPdnIGOpGXfUQf6jjBM8XMQeAKP_p5V1GJZcgeNo04l_mJOKjLqEYbza49pzUAc2xfiaySAcNwdKwwwdLdSLTNNG-xgWTd4O_gaSJiBoXFCZrmnERgKZQu7w"
+  "RawRsaPublicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuWo6PSf93wsXl2vvJFO2\naUTcYK/FWjl4kOPV1puz/wmyzTltIOCC7Sb9z7TfT07Mr8CNXZo2qMtJ1Iq15Grk\nsv4/2HEZZykUxu3RSRrdkqH8xGmyo7Nu+Kf7Uij+ObUfCc5UG3Yw6ats9M2gXMOw\nA4m6XgLMJfqEUoViH9gJ6Z9sDCFncO1emRxIUKvhUYY+TSsO1pu/qUXSiDIKCoX+\ndvVV/JxquHLZRedc82W16I+5kZKZto/xW3jALe0HsR4J8o89Ei5FZGgCEMmskowB\n7ScwHTJjUOaCCwOlTrTskFjeJmELuEtffJkB1UQb42Dg+0ji0jdd408d//rmP7xy\nlwIDAQAB\n-----END PUBLIC KEY-----\n",
+  "TokenExpired": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOiJDYXJsIERlIGxhIEJhdHRlIiwiZXhwIjoxNDg1OTY5NzAwLCJpYXQiOjE0NTMyMjU0NzMsImlzcyI6ImFiOTBiYzU4ZWY3NjEyMzQxMjM0MTIzNCIsInJvbGVzIjpbeyJuYW1lIjoiY3A6Y2xpZW50OnJpZGVyOiJ9XSwic3ViIjoiYWI5MGJjNThlZjc2MTIzNDEyMzQxMjM0In0.l8G1RBpov6WjRN0oxzqiAx6bLQ81zGgWPF7u8Y6QypZRmI2JhuWbzsIvqAOPB2j15efxvDOx3dGcYwUN0ywomOaqGgnTAftgoveBdZvn3kDJ1m-a0jYzSFsdDXUumetEtMIGvuYAJAP4UWwKyUqhJ7RZ5N8F48N7MFt3Kts037rfsXDkxa8UhwhBkNEmW8by4J6x98gmt-IR-BnfaKtr6xhSvICrxNWP96eKiPnfDeohH9UDaYndGYZS8X4RbcLtjbF_9ubwEcWy1uEpYMhNuc_iSQfx3H6hGHt_iRdZni7VP3ChfKc0eE3oLqCr76UyTIxVIUvlfYwm_KMg9trD0Q",
+  "TokenValidWithEmployeeRole": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOiJIdWJlcnQgQm9uaXNzZXVyIGRlIExhIEJhdGgiLCJpYXQiOjE0NTMyMjU0NzMsImlzcyI6IjU4ZWY3NmFiOTBiYzEyMzQxMjM0MTIzNCIsInJvbGVzIjpbeyJuYW1lIjoiY3A6ZW1wbG95ZWU6In1dLCJzdWIiOiI1OGVmNzZhYjkwYmMxMjM0MTIzNDEyMzQifQ.V2zW797fcIMn9T9ehSbCc5ZwIahn0DaTDBSZeHwW_k6w5U0KR4GUFNSO8g06JVATGdUqYT8gajx63llEq-UUzq9VkBN4bovGV2Nxa_ZGVHa2WZfZCq40FGYVnHQKkB8smr1oYxHqj-GvuhLgAX4k_EniuR8rbiF50VcKYM_6FaPpu9GYTU-ACN4xk6la3YrpcXuf9TQU2lPNpdwZkzCSfRD2EryBw-IAO209ifPhnVy8Rxe0Nv97r9V_7CsBAk207K-m70g-viqvfqyqtOo17XSU6vq93rz7q_IDSTnoGccy7QuCURLg-sSTOsM4EKIkbz0ikNHkHJvRkzKg1OTySw",
+  "TokenValidWithRiderRole": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOiJBbGZyZWQgQmVybmFyZCIsImlhdCI6MTQ1MzIyNTQ3MywiaXNzIjoiNThlZjc2YWI5MGJjMTIzNDEyMzQxMjM0Iiwicm9sZXMiOlt7Im5hbWUiOiJjcDpjbGllbnQ6cmlkZXI6In1dLCJzdWIiOiI1OGVmNzZhYjkwYmMxMjM0MTIzNDEyMzQifQ.s4HcEjuTIxxWgX6RnlajYnt_G05hLS_IW_v2AIUn1IP4Mb0HMTBeDg-zzpAvsfOZCsrbzgaxhQsUozbAp6cnaZem8sp8jSACj_kpplkfUqKBzZnrG71GYjMhkDd44HNP3_k9_dlhySKHj5lL8oWJYCGYUvnkyrP7dS_p4iSM_BNz0RkZEvz5mkqi7bIFlDURiIz6HzAaw8A5KtTfo5VnJWsp7mNo1lrS942YCSC_Ng79SmXlHTmMISNeZh41sclqOk2Y0URJCnh1H0g50LeE4RkpF5SwJ8FBZ-BHBPeFBgkFn7CgNAuCbC_9lftVvMWhGBET-InZMk6dQXY5kjuWiw",
+  "TokenWithInvalidAlgorithm": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOiJBbGZyZWQgQmVybmFyZCIsImlhdCI6MTQ1MzIyNTQ3MywiaXNzIjoiNThlZjc2YWI5MGJjMTIzNDEyMzQxMjM0Iiwicm9sZXMiOlt7Im5hbWUiOiJjcDpjbGllbnQ6cmlkZXI6In1dLCJzdWIiOiI1OGVmNzZhYjkwYmMxMjM0MTIzNDEyMzQifQ.s2p067HnNQAaHLZo9MFwr28zni_8gITZPB5zaBuPKHQ",
+  "TokenWithInvalidSignature": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOiJBbGZyZWQgQmVybmFyZCIsImlhdCI6MTQ1MzIyNTQ3MywiaXNzIjoiNThlZjc2YWI5MGJjMTIzNDEyMzQxMjM0Iiwicm9sZXMiOlt7Im5hbWUiOiJjcDpjbGllbnQ6cmlkZXI6In1dLCJzdWIiOiI1OGVmNzZhYjkwYmMxMjM0MTIzNDEyMzQifQ.KFZPoMqChj9gh-h7l9TxgcrdlmRIjeZ1rCyDypzN0vl3CbAnTs3YUxPnMWAlFeBof7GbxXJALhqbfDOJLWnNPNd95LVGQTeIbDqZz8t3F7aRjYOyJ9jLlKQUO8D3PSmIl2a4bayy3_0hxOZvvEsmtU8Z2vWffGm9l4elgFvzGO8RxlhITorexELObwyJw__J9tEe9lhTXWRH9IR6fw22DyE0ny73pWlhOmMTNFToz3xkYcxoE2M3m8WcNDX5MO0aW9F2fr1e-lSaOnSxsBLJwrQHLkhR5MvZZfbY4sE_2X0oSKyDw8Ff5fZPQx1_-rLaAhacHgWvcQYK1i5nsOAfAw"
 }

--- a/scripts/generateFixtures.go
+++ b/scripts/generateFixtures.go
@@ -26,8 +26,8 @@ type pseudoRole map[string]string
 type pseudoJSObject map[string]interface{}
 
 var riderClaims = jwt.MapClaims{
-	"iss":          "58ef76ab90bc",
-	"sub":          "58ef76ab90bc",
+	"iss":          "58ef76ab90bc123412341234",
+	"sub":          "58ef76ab90bc123412341234",
 	"display_name": "Alfred Bernard",
 	"roles": []pseudoRole{{
 		"name": "cp:client:rider:",
@@ -36,8 +36,8 @@ var riderClaims = jwt.MapClaims{
 }
 
 var employeeClaims = jwt.MapClaims{
-	"iss":          "58ef76ab90bc",
-	"sub":          "58ef76ab90bc",
+	"iss":          "58ef76ab90bc123412341234",
+	"sub":          "58ef76ab90bc123412341234",
 	"display_name": "Hubert Bonisseur de La Bath",
 	"roles": []pseudoRole{{
 		"name": "cp:employee:",
@@ -46,8 +46,8 @@ var employeeClaims = jwt.MapClaims{
 }
 
 var expiredClaims = jwt.MapClaims{
-	"iss":          "ab90bc58ef76",
-	"sub":          "ab90bc58ef76",
+	"iss":          "ab90bc58ef76123412341234",
+	"sub":          "ab90bc58ef76123412341234",
 	"display_name": "Carl De la Batte",
 	"roles": []pseudoRole{{
 		"name": "cp:client:rider:",


### PR DESCRIPTION
Currently, IDP generates token with 24 hex chars sub and iss fields.

This commit makes the fixture more realistic by making them use fields
with the same length