### PR TITLE
SECU-915 add verify token check, add unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.8
+      - image: circleci/golang:1.12.7
     working_directory: /go/src/github.com/transcovo/go-chpr-logger
 
     steps:

--- a/examples_test.go
+++ b/examples_test.go
@@ -22,7 +22,7 @@ func ExampleChainMiddlewares() {
 
 	handler := ChainMiddlewares([]Middleware{
 		RecoveryMiddleware(logger),
-		JwtAuthenticationMiddleware("some public key string", logger),
+		JwtAuthenticationMiddleware("some public key string", logger, true, false),
 		RoleAuthorizationMiddleware("cp:client:rider:", "cp:employee:tech:"),
 		ParamsMiddleware(requestParamsGetter),
 	}, myHandler)

--- a/jwtAuth.go
+++ b/jwtAuth.go
@@ -107,7 +107,7 @@ func JwtAuthenticationMiddleware(publicKeysListAsString string, logger *logrus.L
 	return func(next http.HandlerFunc) http.HandlerFunc {
 		return func(res http.ResponseWriter, req *http.Request) {
 			token := retrieveTokenFromHeader(req)
-			if !IsVerifyToken() {
+			if !ShouldVerifyToken() {
 				parsed, _, err :=  new(jwt.Parser).ParseUnverified(string(token), &TokenClaims{});
 
 				if err != nil {
@@ -194,7 +194,7 @@ func validateTokenAndExtractClaims(token rawToken, publicKey *rsa.PublicKey) (*T
 }
 
 func extractClaims(parsed *jwt.Token) (*TokenClaims, error) {
-	if !parsed.Valid && IsVerifyToken() {
+	if ShouldVerifyToken() && !parsed.Valid {
 		return nil, ErrInvalidToken
 	}
 
@@ -223,8 +223,8 @@ func GetClaims(request *http.Request) *TokenClaims {
 }
 
 /*
-IsVerifyToken is true when the AUTHENTICATION_VERIFY_TOKEN_SIGNATURE is properly set
+ShouldVerifyToken is true when the AUTHENTICATION_VERIFY_TOKEN_SIGNATURE is properly set
 */
-func IsVerifyToken() bool {
-	return os.Getenv("AUTHENTICATION_VERIFY_TOKEN_SIGNATURE") == "true"
+func ShouldVerifyToken() bool {
+	return os.Getenv("AUTHENTICATION_VERIFY_TOKEN_SIGNATURE") != "false"
 }

--- a/jwtAuth_test.go
+++ b/jwtAuth_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestMiddleware_OneKeyUnauthorized(t *testing.T) {
-	os.Setenv("AUTHENTICATION_VERIFY_TOKEN_SIGNATURE", "true")
 	jwtMiddleware := JwtAuthenticationMiddleware(fixtures.Fixtures.RawRsaPublicKey, &logrus.Logger{})
 	wrappedHandler := jwtMiddleware(fixtures.Fake200Handler)
 

--- a/jwtAuth_test.go
+++ b/jwtAuth_test.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"crypto/rsa"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -112,7 +111,7 @@ func TestMiddleWare_StoreInformationInRequestcontext_WithVerifyToken_WithExpired
 }
 
 func TestMiddleWare_StoreInformationInRequestcontext_WithoutVerifyToken_WithExpiredToken(t *testing.T) {
-	jwtMiddleware := JwtAuthenticationMiddleware(fixtures.Fixtures.RawRsaPublicKey, &logrus.Logger{}, false, false)
+	jwtMiddleware := JwtAuthenticationMiddleware("", &logrus.Logger{}, false, false)
 	modifiedRequest := &http.Request{}
 	fakeHandler := func(res http.ResponseWriter, req *http.Request) {
 		modifiedRequest = req
@@ -189,8 +188,8 @@ func TestRetrieveTokenFromHeader_Success(t *testing.T) {
 
 func TestGetParsedToken_InvalidAlgorithm_WithoutVerifyToken(t *testing.T) {
 	token := rawToken(fixtures.Fixtures.TokenWithInvalidAlgorithm)
-	publicKeys := []*rsa.PublicKey{fixtures.GetRsaPublicKey()}
-	parsed, err := getParsedToken(token, publicKeys, false, false)
+	rawPublicKey := fixtures.Fixtures.RawRsaPublicKey
+	parsed, err := getParsedToken(token, rawPublicKey, false, false, &logrus.Logger{})
 	assert.NoError(t, err)
 	assert.NotNil(t, parsed)
 	assert.Equal(t,
@@ -202,8 +201,8 @@ func TestGetParsedToken_InvalidAlgorithm_WithoutVerifyToken(t *testing.T) {
 
 func TestGetParsedToken_ExpiredToken_WithVerifyToken_WithoutIgnoreExpiration(t *testing.T) {
 	token := rawToken(fixtures.Fixtures.TokenExpired)
-	publicKeys := []*rsa.PublicKey{fixtures.GetRsaPublicKey()}
-	parsed, err := getParsedToken(token, publicKeys, true, false)
+	rawPublicKey := fixtures.Fixtures.RawRsaPublicKey
+	parsed, err := getParsedToken(token, rawPublicKey, true, false, &logrus.Logger{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "token is expired by")
 	assert.Nil(t, parsed)
@@ -211,8 +210,8 @@ func TestGetParsedToken_ExpiredToken_WithVerifyToken_WithoutIgnoreExpiration(t *
 
 func TestGetParsedToken_ExpiredToken_WithVerifyToken_WithIgnoreExpiration(t *testing.T) {
 	token := rawToken(fixtures.Fixtures.TokenExpired)
-	publicKeys := []*rsa.PublicKey{fixtures.GetRsaPublicKey()}
-	parsed, err := getParsedToken(token, publicKeys, true, true)
+	rawPublicKey := fixtures.Fixtures.RawRsaPublicKey
+	parsed, err := getParsedToken(token, rawPublicKey, true, true, &logrus.Logger{})
 	assert.NoError(t, err)
 	assert.NotNil(t, parsed)
 }

--- a/roles_test.go
+++ b/roles_test.go
@@ -42,7 +42,7 @@ func TestRoleAuthorizationMiddleware_Forbidden(t *testing.T) {
 }
 
 func TestRoleAuthorizationMiddleware_ChainedSuccess(t *testing.T) {
-	jwtMiddleware := JwtAuthenticationMiddleware(fixtures.Fixtures.RawRsaPublicKey, &logrus.Logger{})
+	jwtMiddleware := JwtAuthenticationMiddleware(fixtures.Fixtures.RawRsaPublicKey, &logrus.Logger{}, true, false)
 	employeeMiddleware := RoleAuthorizationMiddleware("cp:client:rider:")
 	wrappedHandler := jwtMiddleware(employeeMiddleware(fixtures.Fake200Handler))
 
@@ -54,7 +54,7 @@ func TestRoleAuthorizationMiddleware_ChainedSuccess(t *testing.T) {
 }
 
 func TestRoleAuthorizationMiddleware_ChainedForbidden(t *testing.T) {
-	jwtMiddleware := JwtAuthenticationMiddleware(fixtures.Fixtures.RawRsaPublicKey, &logrus.Logger{})
+	jwtMiddleware := JwtAuthenticationMiddleware(fixtures.Fixtures.RawRsaPublicKey, &logrus.Logger{}, true, false)
 	employeeMiddleware := RoleAuthorizationMiddleware("cp:employee:")
 	wrappedHandler := jwtMiddleware(employeeMiddleware(fixtures.Fake200Handler))
 

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -6,7 +6,7 @@ go get -t .
 
 go vet $(go list ./... | grep -v /vendor/)
 
-go get github.com/golang/lint/golint
+go get golang.org/x/lint/golint
 golint -set_exit_status $(go list ./... | grep -v /vendor/)
 
 echo "mode: set" > coverage.txt

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -7,7 +7,7 @@ go get -t .
 
 go vet $(go list ./... | grep -v /vendor/)
 
-go get -u github.com/golang/lint/golint
+go get -u golang.org/x/lint/golint
 golint -set_exit_status $(go list ./... | grep -v /vendor/)
 
 for d in $(go list ./... | grep -v vendor); do


### PR DESCRIPTION
### JIRA
https://transcovo.atlassian.net/browse/SECU-915

### Context
It has been decided that identity-provider should not be considered as a critical micro-service and the blocking point is the refresh token.

To make this happen, the new state of mind is that the authentication (token's signature check and token's expiration check) will be only made on stargate / drivergate / bo-gateway and the other applications (as they are not public and not accessible from outside) will only be checking the authorizations (the user's roles).

### Purpose of this PR

This PR will update the go-middlewares to consider the case when we don't need to verify the token, just decode it instead